### PR TITLE
Fixes: Control case of column_names selected from Information_Schema.…

### DIFF
--- a/pg_chameleon/lib/mysql_lib.py
+++ b/pg_chameleon/lib/mysql_lib.py
@@ -248,7 +248,7 @@ class mysql_source(object):
 		"""
 		sql_tables="""
 			SELECT 
-				table_name
+				table_name as table_name
 			FROM 
 				information_schema.TABLES 
 			WHERE 
@@ -316,17 +316,17 @@ class mysql_source(object):
 		"""
 		sql_metadata="""
 			SELECT 
-				column_name,
-				column_default,
-				ordinal_position,
-				data_type,
-				column_type,
-				character_maximum_length,
-				extra,
-				column_key,
-				is_nullable,
-				numeric_precision,
-				numeric_scale,
+				column_name as column_name,
+				column_default as column_default,
+				ordinal_position as ordinal_position,
+				data_type as data_type,
+				column_type as column_type,
+				character_maximum_length as character_maximum_length,
+				extra as extra,
+				column_key as column_key,
+				is_nullable as is_nullable,
+				numeric_precision as numeric_precision,
+				numeric_scale as numeric_scale,
 				CASE 
 					WHEN data_type="enum"
 				THEN	
@@ -355,11 +355,11 @@ class mysql_source(object):
 		self.logger.info("retrieving foreign keys metadata for schemas %s" % schema_replica)
 		sql_fkeys = """ 
 			SELECT
-				table_name,
-				table_schema,
-				constraint_name,
-				referenced_table_name,
-				referenced_table_schema,
+				table_name as table_name,
+				table_schema as table_schema,
+				constraint_name as constraint_name,
+				referenced_table_name as referenced_table_name,
+				referenced_table_schema as referenced_table_schema,
 				GROUP_CONCAT(concat('"',column_name,'"') ORDER BY POSITION_IN_UNIQUE_CONSTRAINT) as fk_cols,
 				GROUP_CONCAT(concat('"',REFERENCED_COLUMN_NAME,'"') ORDER BY POSITION_IN_UNIQUE_CONSTRAINT) as ref_columns
 			FROM
@@ -419,7 +419,7 @@ class mysql_source(object):
 					WHEN 
 						data_type IN ('datetime','timestamp','date')
 					THEN
-						concat('nullif(`',column_name,'`,"0000-00-00 00:00:00")')
+						concat('nullif(`',column_name,'`,cast("0000-00-00 00:00:00" as date))')
 
 				ELSE
 					concat('cast(`',column_name,'` AS char CHARACTER SET """+ self.charset +""")')
@@ -437,14 +437,14 @@ class mysql_source(object):
 					WHEN 
 						data_type IN ('datetime','timestamp','date')
 					THEN
-						concat('nullif(`',column_name,'`,"0000-00-00 00:00:00") AS `',column_name,'`')
+						concat('nullif(`',column_name,'`,cast("0000-00-00 00:00:00" as date)) AS `',column_name,'`')
 					
 				ELSE
 					concat('cast(`',column_name,'` AS char CHARACTER SET """+ self.charset +""") AS','`',column_name,'`')
 					
 				END
 				AS select_stat,
-				column_name
+				column_name as column_name
 			FROM 
 				information_schema.COLUMNS 
 			WHERE 
@@ -509,7 +509,7 @@ class mysql_source(object):
 		self.logger.debug("estimating rows in %s.%s" % (schema , table))
 		sql_rows = """ 
 			SELECT 
-				table_rows,
+				table_rows as table_rows,
 				CASE
 					WHEN avg_row_length>0
 					then
@@ -660,8 +660,8 @@ class mysql_source(object):
 		self.logger.debug("Creating indices on table %s.%s " % (schema, table))
 		sql_index = """
 			SELECT 
-				index_name,
-				non_unique,
+				index_name as index_name,
+				non_unique as non_unique,
 				GROUP_CONCAT(column_name ORDER BY seq_in_index) as index_columns
 			FROM
 				information_schema.statistics
@@ -894,8 +894,8 @@ class mysql_source(object):
 		for schema in self.schema_replica:
 			sql_tables = """	
 				SELECT 
-					table_schema,
-					table_name
+					table_schema as table_schema,
+					table_name as table_name
 				FROM 
 					information_schema.TABLES 
 				WHERE 
@@ -910,8 +910,8 @@ class mysql_source(object):
 				column_type = {}
 				sql_columns = """
 					SELECT 
-						column_name,
-						data_type
+						column_name as column_name,
+						data_type as data_type
 					FROM 
 						information_schema.COLUMNS 
 					WHERE 


### PR DESCRIPTION
## Control case of column_names selected from Information_Schema.
Related Issue from main pg_chameleon repo:  https://github.com/the4thdoctor/pg_chameleon/issues/96
Related MySQL bug report: https://bugs.mysql.com/bug.php?id=84456

Resolves the following error when used with MySQL 8.0.18:
```
2019-11-22 13:06:28 MainProcess DEBUG pg_lib.py (620): Changing the autocommit flag to True
2019-11-22 13:06:28 MainProcess DEBUG pg_lib.py (3070): Collecting schema mappings for source dfpl
2019-11-22 13:06:28 MainProcess INFO pg_lib.py (1846): deleting all the table references from the replica catalog for source dfpl 
Traceback (most recent call last):
  File "/home/chameleon/venv/bin/chameleon", line 5, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/chameleon/venv/bin/chameleon.py", line 58, in <module>
    getattr(replica, args.command)()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/global_lib.py", line 327, in init_replica
    self.__init_mysql_replica()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/global_lib.py", line 337, in __init_mysql_replica
    self.mysql_source.init_replica()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/mysql_lib.py", line 1374, in init_replica
    self.get_table_list()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/mysql_lib.py", line 261, in get_table_list
    table_list = [table["table_name"] for table in self.cursor_buffered.fetchall()]
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/mysql_lib.py", line 261, in <listcomp>
    table_list = [table["table_name"] for table in self.cursor_buffered.fetchall()]
KeyError: 'table_name'

```

## Cast "0000-00-00 00:00:00" as date.
Resolves the following error when used with MySQL 8.0.18:
```
2019-11-22 14:35:26 MainProcess DEBUG mysql_lib.py (548): Executing query for table dfpl.IMP_PLT
2019-11-22 14:35:26 MainProcess INFO mysql_lib.py (703): Could not copy the table IMP_PLT. Excluding it from the replica.
2019-11-22 14:35:26 MainProcess DEBUG mysql_lib.py (304): Dropping the schema _dfpl_tmp.
2019-11-22 14:35:26 MainProcess DEBUG pg_lib.py (658): Changing the lock timeout for the session to 120s.
2019-11-22 14:35:26 MainProcess CRITICAL mysql_lib.py (1400): init replica for source dfpl failed
Traceback (most recent call last):
  File "/home/chameleon/venv/bin/chameleon", line 5, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/chameleon/venv/bin/chameleon.py", line 58, in <module>
    getattr(replica, args.command)()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/global_lib.py", line 327, in init_replica
    self.__init_mysql_replica()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/global_lib.py", line 337, in __init_mysql_replica
    self.mysql_source.init_replica()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/mysql_lib.py", line 1381, in init_replica
    self.__copy_tables()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/mysql_lib.py", line 699, in __copy_tables
    master_status = self.copy_data(schema, table)
  File "/home/chameleon/venv/lib/python3.5/site-packages/pg_chameleon/lib/mysql_lib.py", line 550, in copy_data
    self.cursor_unbuffered.execute(sql_csv)
  File "/home/chameleon/venv/lib/python3.5/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/chameleon/venv/lib/python3.5/site-packages/pymysql/cursors.py", line 455, in _query
    conn.query(q, unbuffered=True)
  File "/home/chameleon/venv/lib/python3.5/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/chameleon/venv/lib/python3.5/site-packages/pymysql/connections.py", line 725, in _read_query_result
    result.init_unbuffered_query()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pymysql/connections.py", line 1092, in init_unbuffered_query
    first_packet = self.connection._read_packet()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/chameleon/venv/lib/python3.5/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/chameleon/venv/lib/python3.5/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1525, "Incorrect DATE value: '0000-00-00 00:00:00'")
```